### PR TITLE
Change sourcecode format from ts to tsx

### DIFF
--- a/template/main.typ
+++ b/template/main.typ
@@ -113,7 +113,7 @@ Quellcode mit entsprechender Formatierung wird wie folgt eingefügt:
 
 #figure(
   caption: "Ein Stück Quellcode",
-  sourcecode[```ts
+  sourcecode[```tsx
     const ReactComponent = () => {
       return (
         <div>


### PR DESCRIPTION
The syntax highlighting of the TSX code snippet was incorrectly set to `ts`.